### PR TITLE
:bug: Reset terminal settings after error

### DIFF
--- a/src/loc.c
+++ b/src/loc.c
@@ -52,4 +52,5 @@ void loc_err(const loc_t loc, const m_str filename) {
   gw_err("\033[0m");
   fclose(f);
   free(line);
+  gw_err("\033[1m%s:%u:%u:\033[0m ", filename, loc->first.line, loc->first.column);
 }


### PR DESCRIPTION
Add gw_err() at the end of loc_err to reset the terminal settings which
prevents unnecessary underlines after syntax errors.
Fixes #5